### PR TITLE
Fixed FE on attempting to lock an unassigned mDbHelper

### DIFF
--- a/src/info/guardianproject/notepadbot/NotesDbAdapter.java
+++ b/src/info/guardianproject/notepadbot/NotesDbAdapter.java
@@ -157,8 +157,10 @@ public class NotesDbAdapter {
     
     public void close() {
     	
-    	
+    	if (!(mDbHelper == null))
+    	{
         mDbHelper.close();
+    	}
     }
 
 


### PR DESCRIPTION
Trivial change, but it's always nice to see less FEs...
