### PR TITLE
font resize problem

### DIFF
--- a/app/src/info/guardianproject/notepadbot/NoteEdit.java
+++ b/app/src/info/guardianproject/notepadbot/NoteEdit.java
@@ -22,6 +22,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.EditText;
@@ -108,7 +109,7 @@ public class NoteEdit extends Activity implements ICacheWordSubscriber {
         float pxSize = mBodyText.getTextSize();
         pxSize *= factor;
 
-        mBodyText.setTextSize(pxSize);
+        mBodyText.setTextSize(TypedValue.COMPLEX_UNIT_PX, pxSize);
     }
 
     private void setupView(boolean hasImage)


### PR DESCRIPTION
On the Nexus 7 virtual device, the menu choices to make the font smaller instead made the font larger. While debugging and stepping through the code I saw that the text size returned on line 109 of `NoteEdit.java` increased over successive selections of the "Smaller" menu option - the opposite of what it should have done, but that explained the visual change that I was seeing on screen.

I found that this behavior was fixed with a change to the `setTextSize()` call on line 111 to explicitly set the unit of change.
