### PR TITLE
Resolves exception during edit when restoring focus

### DIFF
--- a/app/src/info/guardianproject/notepadbot/NoteEdit.java
+++ b/app/src/info/guardianproject/notepadbot/NoteEdit.java
@@ -198,6 +198,7 @@ public class NoteEdit extends Activity implements ICacheWordSubscriber {
             mTitleText.setText(note.getString(
                     note.getColumnIndexOrThrow(NotesDbAdapter.KEY_TITLE)));
 
+            stopManagingCursor(note);
             note.close();
 
         } catch (Exception e)


### PR DESCRIPTION
Resolves issue #17 where app dies when if editing a note, then switching to another app, and then switching back.
